### PR TITLE
secrets.ymlをgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 
 public/uploads/*
 .DS_Store
+config/secrets.yml


### PR DESCRIPTION
# What
secrets.ymlファイルをgitignoreに追加した。

# Why
gitignoreにsecrets.ymlをプッシュしないようにするため。