### PR TITLE
商品詳細ページの編集・削除・購入ボタンのビュー実装。パスの実装。

### DIFF
--- a/app/assets/stylesheets/modules/_items.show.scss
+++ b/app/assets/stylesheets/modules/_items.show.scss
@@ -1,3 +1,18 @@
+@mixin button {
+  display: block;
+  height: 50px;
+  width: 100%;
+  line-height: 50px;
+  color: #fff;
+  font-size: 24px;
+  font-weight: normal;
+  border: 1px solid;
+  border-radius: 100px;
+  text-decoration: none;
+  background-color: pink;
+  margin-bottom: 10px;
+}
+
 .navbar {
   height: 54px;
   width: 100%;
@@ -150,21 +165,10 @@
       padding-top: 40px;
       text-align: center;
       &--editBtn {
-        display: block;
-        height: 50px;
-        width: 100%;
-        line-height: 50px;
-        color: #fff;
-        font-size: 24px;
-        font-weight: normal;
-        border: 1px solid;
-        border-radius: 100px;
-        text-decoration: none;
-        background-color: pink;
-        margin-bottom: 10px;
+        @include button;
       }
       &--deleteBtn {
-        @extend .item__edit--editBtn;
+        @include button;
         background-color: gray;
         width: 70%;
         margin: 10px auto 0;
@@ -174,7 +178,7 @@
       padding-top: 40px;
       text-align: center;
       &--btn {
-        @extend .item__edit--editBtn;
+        @include button;
         height: 100px;
         line-height: 100px;
         font-weight: bold;

--- a/app/assets/stylesheets/modules/_items.show.scss
+++ b/app/assets/stylesheets/modules/_items.show.scss
@@ -146,8 +146,41 @@
         }
       }
     }
+    &__edit {
+      padding-top: 40px;
+      text-align: center;
+      &--editBtn {
+        display: block;
+        height: 50px;
+        width: 100%;
+        line-height: 50px;
+        color: #fff;
+        font-size: 24px;
+        font-weight: normal;
+        border: 1px solid;
+        border-radius: 100px;
+        text-decoration: none;
+        background-color: pink;
+        margin-bottom: 10px;
+      }
+      &--deleteBtn {
+        @extend .item__edit--editBtn;
+        background-color: gray;
+        width: 70%;
+        margin: 10px auto 0;
+      }
+    }
+    &__purchase {
+      padding-top: 40px;
+      text-align: center;
+      &--btn {
+        @extend .item__edit--editBtn;
+        height: 100px;
+        line-height: 100px;
+        font-weight: bold;
+      }
+    }
   }
-
   .comment {
     padding: 24px;
     margin: 10px auto;

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -97,7 +97,7 @@
         .item__edit
           = link_to "商品を編集する", edit_item_path(@item.id), method: :get, class: "item__edit--editBtn"
           or
-          = link_to "削除", item_path(@item.id), method: :delete, data: {confirm: '本当に削除しますか?'}, class: "item__edit--deleteBtn"
+          = link_to "削除", item_path(@item.id),data: {confirm: '本当に削除しますか?'}, class: "item__edit--deleteBtn"
       - else
         .item__purchase
           = link_to "購入画面に進む", purchase_item_path, method: :get, class: "item__purchase--btn"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -92,6 +92,15 @@
       .item__option__report
         = icon("fas", "far-flag")
         = link_to "不適切な商品の通報", "#", class: "item__option__report--link"
+    - if user_signed_in?
+      - if current_user.id == @item.seller_id
+        .item__edit
+          = link_to "商品を編集する", edit_item_path(@item.id), method: :get, class: "item__edit--editBtn"
+          or
+          = link_to "削除", item_path(@item.id), method: :delete, data: {confirm: '本当に削除しますか?'}, class: "item__edit--deleteBtn"
+      - else
+        .item__purchase
+          = link_to "購入画面に進む", purchase_item_path, method: :get, class: "item__purchase--btn"
   .comment
     %textarea.comment__body
     .comment__notes


### PR DESCRIPTION
# What
商品詳細ページに、編集・削除・購入ボタンを実装。
編集・削除ボタンは、出品者にしか表示されない。
購入ボタンは、出品者以外に表示される。
未ログイン状態では商品詳細ページの閲覧はできるが、上記ボタンはいずれも表示されない。

# Why
フリマアプリにおいて必須実装のため。

# 削除機能について
ボタンをクリックした際にポップアップメッセージで削除確認。
ただしdeleteを実行すると、アソシエーション等の関係で現状はエラー表示になる。削除は別タスクのため、削除機能はこのブランチでは実装せず別ブランチで対応。

# 実装画面キャプチャ
ログインユーザーと商品出品者が一致するとき↓
https://gyazo.com/c3df9239482f30ad1a20fbac1d2cfabc

ログインユーザーと、商品出品者が違うとき↓
https://gyazo.com/8a3249ea4c96a1a08633d1fb1ee17402