### PR TITLE
ユーザー新規会員登録正規表現実装

### DIFF
--- a/app/models/phone.rb
+++ b/app/models/phone.rb
@@ -1,4 +1,4 @@
 class Phone < ApplicationRecord
   belongs_to :user, optional: true
-  validates :phone_number, presence: true
+  validates :phone_number, presence: true, uniqueness: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,8 @@ class User < ApplicationRecord
   
   validates :email, presence: true, uniqueness: true, format: { with: /\A\S+@\S+\.\S+\z/ }
 
+  validates :password, :password_confirmation, presence: true, length: { minimum: 7 }
+
   validates :family_name, :first_name, presence: true, format: { with: /\A(?:\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々])+\z/ }
 
   validates :family_name_kana, :first_name_kana, presence: true, format: { with: /\A[ァ-ヶー－]+\z/ }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
     validates :birth_month
     validates :birth_day
   end
-  
+
   validates :email, presence: true, uniqueness: true, format: { with: /\A\S+@\S+\.\S+\z/ }
 
   validates :password, :password_confirmation, presence: true, length: { minimum: 7 }
@@ -24,5 +24,4 @@ class User < ApplicationRecord
   validates :family_name, :first_name, presence: true, format: { with: /\A(?:\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々])+\z/ }
 
   validates :family_name_kana, :first_name_kana, presence: true, format: { with: /\A[ァ-ヶー－]+\z/ }
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,5 +10,17 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  validates :nickname, :family_name, :first_name, :family_name_kana, :first_name_kana, presence: true
+  with_options presence: true do
+    validates :nickname
+    validates :birth_year
+    validates :birth_month
+    validates :birth_day
+  end
+  
+  validates :email, presence: true, uniqueness: true, format: { with: /\A\S+@\S+\.\S+\z/ }
+
+  validates :family_name, :first_name, presence: true, format: { with: /\A(?:\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々])+\z/ }
+
+  validates :family_name_kana, :first_name_kana, presence: true, format: { with: /\A[ァ-ヶー－]+\z/ }
+
 end


### PR DESCRIPTION
# What
- メールアドレスは、@とドメインを含んだものを許可。
- ユーザーの名前・名字は、漢字、全角カタカナ、ひらがなのみ許可。
- ユーザーの名前・名字(カナ)は、全角カタカナのみ許可。
それぞれバリデーションの設定を行なった。

# Why
正確な情報をデータベースに保存するため。