### PR TITLE
編集ページへの遷移、ビュー作成

### DIFF
--- a/app/assets/stylesheets/modules/_items-edit.scss
+++ b/app/assets/stylesheets/modules/_items-edit.scss
@@ -1,0 +1,249 @@
+.product-listing {
+  background-color: #efefef;
+}
+
+.header-logo{
+  text-align: center;
+  h1 {
+    display: inline-block;
+    margin: 40px 0 40px;
+  }
+  a {
+    display: inline-block;
+    width: 185px;
+    height: 49px;
+  }
+  img {
+    width: 185px;
+    height: 49px;
+  }
+}
+
+.sell-main{ 
+  &__container {
+    background-color: #fff;
+    width: 700px;
+    margin: 0 auto;
+
+    .error {
+      color: red;
+      font-size: 14px;
+      font-weight: normal;
+    }
+
+  }
+  &__content {
+    padding: 40px 0 ;
+    height: 100%;
+    border-bottom: solid 1px #efefef;
+  }
+  &__image-title {
+    font-weight: bold;
+    font-size: 14px;
+    display: inline-block;
+    padding-left: 30px;
+  }
+  &__image-guide {
+    font-size: 14px;
+    color: #555555;
+    margin: 15px 30px;
+  }
+  &__image-box {
+    padding-left: 30px;
+  }
+  &__require {
+    background: #ea352d;
+    color: #fff;
+    padding: 2px 4px;
+    border-radius: 2px;
+    margin-left: 6px;
+    font-size: 12px;
+  }
+  &__sub-head {
+    display: inline-block;
+    padding: 0 0 0 30px;
+    font-size: 13px;
+    font-weight: bold;
+    color: #777777;
+    margin-bottom: 25px;
+  }
+  &__price {
+    height: 200px;
+  }
+  &__btn{
+    font-weight: bold;
+    display: block;
+    width: 360px;
+    height: 48px;
+    margin: 0 auto 20px;
+    border-radius: 5px;
+    text-decoration: none;
+    text-align: center;
+    line-height: 48px;
+    &--exhibition {
+      background: #ea352d;
+      color: #fff;
+    }
+    &--draft {
+      background: #ccc;
+      color: #222;
+    }
+    &--return {
+      color: #66CCFF;
+      font-weight: normal;
+    }
+    &__bottom-clear {
+      border-bottom: solid 1px #fff;
+    }
+  }
+}
+
+.form-group {
+  padding: 0 0 20px 30px;
+  label {
+    font-weight: bold;
+    font-size: 14px;
+  }
+  #input-default {
+    display: block;
+    width: 620px;
+    height: 50px;
+    margin-top: 10px;
+    border-radius: 5px;
+    border: solid 1px #AAAAAA;
+    padding: 10px;
+  }
+  &__new-form-area {
+    display: block;
+    width: 620px;
+    height: 150px;
+    margin-top: 10px;
+    border-radius: 5px;
+    border: solid 1px #AAAAAA;
+    font-weight: normal;
+    padding: 15px;
+    font-size: 16px;
+  }
+  &__brand-select {
+    width: 620px;
+    height: 50px;
+    border-radius: 5px;
+    border: solid 1px #AAAAAA;
+    padding-left: 20px;
+    margin-top: 10px;
+  }
+  &__price-select {
+    display: inline-block;
+    width: 250px;
+    height:50px;
+  }
+}
+
+.select {
+  color: white;
+  padding: 2px 4px;
+  border-radius: 2px;
+  margin-left: 6px;
+  font-size: 12px;
+  background: #AAAAAA;
+}
+
+.round-icon {
+  display: inline-block;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  background: #fff;
+  color: #0099e8;
+  line-height: 15px;
+  font-size: 12px;
+  text-align: center;
+  text-decoration: none;
+  border: 1px solid #0099e8;
+  margin-left: 5px;
+}
+
+.price-group {
+  margin-bottom: 30px;
+  position: relative;
+  .sell-price-title {
+    width: 50%;
+    font-weight: bold;
+    font-size: 14px;
+    padding-left: 30px;
+  }
+  .sell-price-input {
+    width: 50%;
+    float: right;
+    display: flex;
+    position: absolute;
+    top: 0px;
+    left: 400px;
+    &__price-select {
+      display: inline-block;
+      width: 250px;
+      height:50px;
+      padding-right: 15px;
+      position: absolute;
+      top: -10px;
+      right: 70px;
+      border-radius: 5px;
+      border: solid 1px #005FFF;
+      text-align: right;
+    }
+  }
+  .sell-price-note {
+    float: right;
+    margin: 30px 15px 0 0;
+    font-size: 13px;
+    color: red;
+  }
+}
+.price-group-border {
+  position: flex;
+  .sell-price-fee {
+  font-size: 13px;
+  padding: 50px 0  20px 30px;
+  border-bottom: solid 1px #efefef;
+ }
+ .sell-price-profit {
+  padding: 30px 0 30px 30px;
+  font-size: 13px;
+}
+}
+
+
+.select-form {
+  margin: 8px 0 15px 0;
+  position: relative;
+  i{
+    position: absolute;
+    right: 70px;
+    top:30%;
+    color: #888;
+    z-index: 10;
+    font-size: 20px;
+    
+  }
+  select{
+    width: 620px;
+    height: 50px;
+    padding-left: 20px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    background: 0;
+    font-size: 16px;
+    line-height: 1.5;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+  }
+}  
+.terms{
+  font-size: 11px;
+  padding: 0 55px 60px;
+  &--links {
+    text-decoration: none;
+    color: #66CCFF;
+  }
+}

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,0 +1,157 @@
+:css
+  header {
+    display: none;
+  }
+
+  .app-banner {
+    display: none;
+  }
+
+  footer {
+    display: none;
+  }
+
+.product-listing
+  .header-logo
+    %h1
+      = link_to root_path do
+        = image_tag asset_path ("material/logo/logo.png"), class: "title-logo"
+  %main.sell-main__container
+    = form_for @item do |f|
+      .sell-main__content
+        %h3.sell-main__image-title
+          出品画像
+        %span.sell-main__require
+          必須
+        %p.sell-main__image-guide
+          最大10枚までアップロードできます
+        .sell-main__image-box
+          #image-box__container
+            = f.fields_for :item_images do |i|
+              .js-file_group{"data-index" => "#{i.index}"}
+                = i.file_field :image_url, class: 'js-file'
+                %br/
+                %span.js-remove 削除
+      .sell-main__content
+        .form-group
+          %label
+            商品名
+            %span.sell-main__require
+              必須
+          %div
+            = f.text_field :name, id: "input-default", placeholder: "40文字まで"
+            %p.error=@item.errors.messages[:name][0]
+        .form-group
+          %label
+            商品の説明
+            %span.sell-main__require
+              必須
+            = f.text_area :description, class: "form-group__new-form-area", placeholder: "商品の説明（必須 1,000文字以内）\n（色、素材、重さ、定価、注意点など）\n例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありませ\nん。あわせやすいのでおすすめです。", rows: "5"
+            %p.error=@item.errors.messages[:description][0]
+      .sell-main__content.clearfix
+        %h3.sell-main__sub-head
+          商品の詳細
+        .sell-form-box
+          .form-group
+            %label
+              カテゴリー
+              %span.sell-main__require
+                必須
+            %div
+              .select-form
+                %i.fa.fa-chevron-down
+                = f.collection_select(:category_id, @parents, :id, :name, {prompt: "選択して下さい"}, {id: "category_select"})
+              .product_select-children
+                %p.error=@item.errors.messages[:category_id][0]
+          .form-group
+            %label
+              ブランド
+              %span.select
+                任意
+            %input{placeholder: "例) シャネル", type: "text", class:"form-group__brand-select"}    
+          .form-group
+            %label
+              商品の状態
+              %span.sell-main__require
+                必須
+            %div
+              .select-form
+                %i.fa.fa-chevron-down
+                = f.select :condition, Item.conditions.keys,{prompt: "選択して下さい"}
+                %p.error=@item.errors.messages[:condition][0]
+      .sell-main__content.clearfix
+        %h3.sell-main__sub-head
+          配送について
+        =link_to "?", '#', class:"round-icon"
+        .sell-form-box
+          .form-group
+            %label
+              配送料の負担
+              %span.sell-main__require
+                必須
+            %div
+              .select-form
+                %i.fa.fa-chevron-down
+                = f.select :shipping_fee, Item.shipping_fees.keys,{prompt: "選択して下さい"}
+                %p.error=@item.errors.messages[:shipping_fee][0]
+          .form-group
+            %label
+              発送元の地域
+              %span.sell-main__require
+                必須
+            %div
+              .select-form
+                %i.fa.fa-chevron-down
+                = f.select :shipping_method, Item.shipping_methods.keys,{prompt: "選択して下さい"}
+                %p.error=@item.errors.messages[:shipping_method][0]
+          .form-group
+            %label
+              発送までの日数
+              %span.sell-main__require
+                必須
+            %div
+              .select-form
+                %i.fa.fa-chevron-down
+                = f.select :shipping_date, Item.shipping_dates.keys,{prompt: "選択して下さい"}
+                %p.error=@item.errors.messages[:shipping_date][0]
+      .sell-main__content--bottom-clear.clearfix
+        %h3.sell-main__sub-head
+          価格（¥300〜9,999,999)
+        = link_to "?", '#', class:"round-icon"
+        .sell-form-box
+          %ul
+            %li.price-group
+              .clear-fix
+                .sell-price-title
+                  %label
+                    販売価格
+                    %span.sell-main__require
+                      必須
+                .sell-price-input
+                  %p
+                    ￥
+                  %div
+                    = f.number_field :price, min:1, max:9999999, class: "sell-price-input__price-select", placeholder: "0"
+                .sell-price-note
+                  %p
+                    300以上9999999以下で入力して下さい
+            %li.price-group-border
+              .clearfix
+                .sell-price-fee
+                  販売手数料  (10%)
+                .sell-price-input
+                  .right
+            %li.price-group-border
+              .clearfix
+                .sell-price-profit
+                  販売利益
+                .sell-price-input
+                  .right
+      .sell-main-content
+        .sell-main__exhibit
+          = f.submit "変更する", class: "sell-main__btn sell-main__btn--exhibition"
+          =link_to "#", class: "sell-main__btn sell-main__btn--draft" do
+            キャンセル
+        %div.terms
+  .registration-footer
+    =render 'devise/registrations/registration-footer'


### PR DESCRIPTION
# what
商品詳細ページから商品編集ページへの遷移と編集ページのビュー作成を行う。
出品者しか編集ボタンが表示できないようにする。

# why
商品編集機能を実装する前の段階として、編集ページの作成が必要であり、
加えてページ間の遷移も必要であるため。

ページの遷移
https://gyazo.com/4585c6ce0a45d16ee79fd6ec9336fe12

出品者しか編集ボタンが表示できないようにする(商品詳細担当実装)
https://gyazo.com/bb47d0fb1821da1f47200eb388a61a0d
