### PR TITLE
出品ページブランドフォーム実装

### DIFF
--- a/app/assets/stylesheets/modules/_items.new.scss
+++ b/app/assets/stylesheets/modules/_items.new.scss
@@ -219,11 +219,10 @@
   i{
     position: absolute;
     right: 70px;
-    top:30%;
+    top:16px;
     color: #888;
     z-index: 10;
     font-size: 20px;
-    
   }
   select{
     width: 620px;

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -68,7 +68,8 @@
               ブランド
               %span.select
                 任意
-            %input{placeholder: "例) シャネル", type: "text", class:"form-group__brand-select"}    
+            %div
+              = f.text_field :brand, class: "form-group__brand-select", placeholder: "例) シャネル"
           .form-group
             %label
               商品の状態


### PR DESCRIPTION
#  What
商品出品ページの
フォームのうちブランドフォームだけ保存ができるフォームにしていなかったため実装する。

# Why
ブランドの登録も任意とはいえきちんと保存される必要があるため。

ブラウザでの表示
[![Screenshot from Gyazo](https://gyazo.com/76612e2070c15fb41a096f0cd59875d5/raw)](https://gyazo.com/76612e2070c15fb41a096f0cd59875d5)
データベースでの保存を確認(3番目の商品)
[![Screenshot from Gyazo](https://gyazo.com/7162b10cdff54e0e8b347b69389f6a1a/raw)](https://gyazo.com/7162b10cdff54e0e8b347b69389f6a1a)
