### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,6 @@
 class Item < ApplicationRecord
   belongs_to :seller, class_name: "User", foreign_key: "seller_id"
-  has_many :item_images
+  has_many :item_images, dependent: :destroy
   belongs_to :category
   accepts_nested_attributes_for :item_images, allow_destroy: true
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -105,7 +105,7 @@
         .item__edit
           = link_to "商品を編集する", edit_item_path(@item.id), method: :get, class: "item__edit--editBtn"
           or
-          = link_to "削除", item_path(@item.id),data: {confirm: '本当に削除しますか?'}, class: "item__edit--deleteBtn"
+          = link_to "削除", item_path(@item.id), method: :delete, data: {confirm: '本当に削除しますか?'}, class: "item__edit--deleteBtn"
       - else
         .item__purchase
           = link_to "購入画面に進む", purchase_item_path, method: :get, class: "item__purchase--btn"


### PR DESCRIPTION
# What
商品削除機能の実装。投稿者だけに削除ボタンが表示されるような機能はすでに実装済み。
ポップアップ表示で削除の可否を確認、その後OKボタンを押すとメインページへ遷移する。

# Why
削除機能は必須実装のため。

#  実装結果の画像

・削除GIF
https://gyazo.com/cac66299875ab115353bd96c2adc793b
<a href="https://gyazo.com/cac66299875ab115353bd96c2adc793b"><img src="https://i.gyazo.com/cac66299875ab115353bd96c2adc793b.gif" alt="Image from Gyazo" width="1000"/></a>


・商品削除前
itemsテーブル
https://gyazo.com/0f299b0f5e1af54879022d9aaa6779b5
![](https://i.gyazo.com/0f299b0f5e1af54879022d9aaa6779b5.png)

item_imagesテーブル
https://gyazo.com/39a47286f5016fa57399564c8fe60f85
![](https://i.gyazo.com/39a47286f5016fa57399564c8fe60f85.png)


・id[4]の商品削除後
itemsテーブル
https://gyazo.com/00df2b7a76b70b5eb2056ec8d162b0c4
![](https://i.gyazo.com/00df2b7a76b70b5eb2056ec8d162b0c4.png)

item_imagesテーブル
https://gyazo.com/9c545cf11f340917ddce8ef22fc9bb83
![](https://i.gyazo.com/9c545cf11f340917ddce8ef22fc9bb83.png)