### PR TITLE
Main page image display　商品一覧表示（出品画像をメインページに反映）

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,8 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
 
   def index
-    @item = Item.all
+    @items = Item.all
+    @item_images = ItemImage.all
   end
   # @item.item_images.newという記述により、
   # newアクションで定義されたitemクラスのインスタンスに関連づけられた

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -12,7 +12,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
-  process resize_to_fit: [800, 800]
+  process resize_to_fit: [200, 300]
   # Provide a default URL as a default if there hasn't been a file uploaded:
   # def default_url(*args)
   #   # For Rails 3.1+ asset pipeline compatibility:

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -93,50 +93,29 @@
           %h1 様々な支払いに対応
           %h2 お支払いは、クレジットカードだけでなく、ポイントや売上金など多彩な方法があります。
 
-  -# ⑤ピックアップカテゴリ
+  -# ⑤ピックアップブランド
   .pickup-category
     %h2 ピックアップカテゴリ
     .category-box
       .box__title
       = link_to "新規投稿商品","#", class: "box__title"
       .box__lists
-        .box__lists--list
-          = link_to "#", class: "box__lists--list" do
-            .image
-              = image_tag "/assets/material/logo/saba.png"
-            .text
-              %h3 product3
-              .price
-                %ul
-                  %li 30000円
-                  %li 
-                    %i.fa.fa-star 0
-                %p (税込)
-        .box__lists--list
-          = link_to "#", class: "box__lists--list" do
-            .image
-              = image_tag "/assets/material/logo/sasami.png"
-            .text
-              %h3 product3
-              .price
-                %ul
-                  %li 30000円
-                  %li 
-                    %i.fa.fa-star 0
-                %p (税込)
-        .box__lists--list
-          = link_to "#", class: "box__lists--list" do
-            .image
-              =image_tag "/assets/material/logo/kare.png"
-            .text
-              %h3 product3
-              .price
-                %ul
-                  %li 30000円
-                  %li 
-                    %i.fa.fa-star 0
-                %p (税込)
-
+        - @items.each do |item|
+          .box__lists--list
+            = link_to item_path(item), class: "box__lists--list" do
+              .image
+                = image_tag item.item_images.first.image_url.to_s if item.item_images.first
+              .text
+                %h3 
+                  = item.name
+                .price
+                  %ul
+                    %li
+                      = item.price
+                      円
+                    %li 
+                      %i.fa.fa-star 0
+                  %p (税込)
   -# ⑥ピックアップブランド
   .pickup-category
     %h2 ピックアップブランド
@@ -144,39 +123,19 @@
       .box__title
       = link_to "アーカイバ","#", class: "box__title"
       .box__lists
-        .box__lists--list
-          = link_to "#", class: "box__lists--list" do
-            .image
-              = image_tag "/assets/material/logo/saba.png"
-            .text
-              %h3 product3
-              .price
-                %ul
-                  %li 30000円
-                  %li 
-                    %i.fa.fa-star 0
-                %p (税込)
-        .box__lists--list
-          = link_to "#", class: "box__lists--list" do
-            .image
-              = image_tag "/assets/material/logo/sasami.png"
-            .text
-              %h3 product3
-              .price
-                %ul
-                  %li 30000円
-                  %li 
-                    %i.fa.fa-star 0
-                %p (税込)
-        .box__lists--list
-          = link_to "#", class: "box__lists--list" do
-            .image
-              = image_tag "/assets/material/logo/kare.png"
-            .text
-              %h3 product3
-              .price
-                %ul
-                  %li 30000円
-                  %li 
-                    %i.fa.fa-star 0
-                %p (税込)
+        - @items.each do |item|
+          .box__lists--list
+            = link_to item_path(item), class: "box__lists--list" do
+              .image
+                = image_tag item.item_images.first.image_url.to_s if item.item_images.first
+              .text
+                %h3 
+                  = item.name
+                .price
+                  %ul
+                    %li
+                      = item.price
+                      円
+                    %li 
+                      %i.fa.fa-star 0
+                  %p (税込)


### PR DESCRIPTION
# What
　商品出品画面で複数枚画像の選択などをした後に出品。その出品した画像（1枚）・商品名・価格をメインページに反映させる
# Why
　・出品した商品がメインページに表示されることで、購入者の欲しい商品が見つけやすくなる。
　・メインページでは画像、商品名、価格の３つのみを表示。購入者が欲しい最低限の情報をメインページで見る事ができる

[![Image from Gyazo](https://i.gyazo.com/352628809cb5a0313b27410bb199fc19.gif)](https://gyazo.com/352628809cb5a0313b27410bb199fc19)