### PR TITLE
出品ページ販売利益計算

### DIFF
--- a/app/assets/javascripts/items/sales_profit.js
+++ b/app/assets/javascripts/items/sales_profit.js
@@ -1,6 +1,6 @@
 $(function(){
   $('#price_calc').on('input', function(){  // リアルタイムで表示したいのでinputを使う。入力の度にイベントが発火するようになる。
-    let data = $('#price_calc').val();  // val()でフォームのvalueを取得(数値)
+    var data = $('#price_calc').val();  // val()でフォームのvalueを取得(数値)
     let profit = Math.round(data * 0.9)  // 手数料計算を行う。dataにかけているのが0.9なのは単に引きたい手数料が10%のため。
     let fee = (data - profit)  // 入力した数値から計算結果(profit)を引くとそれが手数料になる。
     $('.right_bar').html(fee)  // 手数料の表示。html()は追加ではなく上書きする。入力値が変わる度に表示も変わるようにする。

--- a/app/assets/javascripts/items/sales_profit.js
+++ b/app/assets/javascripts/items/sales_profit.js
@@ -1,0 +1,15 @@
+$(function(){
+  $('#price_calc').on('input', function(){  // リアルタイムで表示したいのでinputを使う。入力の度にイベントが発火するようになる。
+    let data = $('#price_calc').val();  // val()でフォームのvalueを取得(数値)
+    let profit = Math.round(data * 0.9)  // 手数料計算を行う。dataにかけているのが0.9なのは単に引きたい手数料が10%のため。
+    let fee = (data - profit)  // 入力した数値から計算結果(profit)を引くとそれが手数料になる。
+    $('.right_bar').html(fee) // 手数料の表示。html()は追加ではなく上書きする。入力値が変わる度に表示も変わるようにする。
+    $('.right_bar').prepend('¥') // 手数料の前に￥マークを付けたい
+    $('.right_bar_2').html(profit)
+    $('.right_bar_2').prepend('¥')
+    if(profit == '') { // もし、計算結果が''なら表示も消す。
+    $('.right_bar').html('ー');
+    $('.right_bar_2').html('ー');
+    }
+  })
+})

--- a/app/assets/javascripts/items/sales_profit.js
+++ b/app/assets/javascripts/items/sales_profit.js
@@ -1,8 +1,8 @@
 $(function(){
   $('#price_calc').on('input', function(){  // リアルタイムで表示したいのでinputを使う。入力の度にイベントが発火するようになる。
     var data = $('#price_calc').val();  // val()でフォームのvalueを取得(数値)
-    let profit = Math.round(data * 0.9)  // 手数料計算を行う。dataにかけているのが0.9なのは単に引きたい手数料が10%のため。
-    let fee = (data - profit)  // 入力した数値から計算結果(profit)を引くとそれが手数料になる。
+    var profit = Math.round(data * 0.9)  // 手数料計算を行う。dataにかけているのが0.9なのは単に引きたい手数料が10%のため。
+    var fee = (data - profit)  // 入力した数値から計算結果(profit)を引くとそれが手数料になる。
     $('.right_bar').html(fee)  // 手数料の表示。html()は追加ではなく上書きする。入力値が変わる度に表示も変わるようにする。
     $('.right_bar').prepend('¥')  // 手数料の前に￥マークを付けたい
     $('.right_bar_2').html(profit)

--- a/app/assets/javascripts/items/sales_profit.js
+++ b/app/assets/javascripts/items/sales_profit.js
@@ -3,11 +3,11 @@ $(function(){
     let data = $('#price_calc').val();  // val()でフォームのvalueを取得(数値)
     let profit = Math.round(data * 0.9)  // 手数料計算を行う。dataにかけているのが0.9なのは単に引きたい手数料が10%のため。
     let fee = (data - profit)  // 入力した数値から計算結果(profit)を引くとそれが手数料になる。
-    $('.right_bar').html(fee) // 手数料の表示。html()は追加ではなく上書きする。入力値が変わる度に表示も変わるようにする。
-    $('.right_bar').prepend('¥') // 手数料の前に￥マークを付けたい
+    $('.right_bar').html(fee)  // 手数料の表示。html()は追加ではなく上書きする。入力値が変わる度に表示も変わるようにする。
+    $('.right_bar').prepend('¥')  // 手数料の前に￥マークを付けたい
     $('.right_bar_2').html(profit)
     $('.right_bar_2').prepend('¥')
-    if(profit == '') { // もし、計算結果が''なら表示も消す。
+    if(profit == '') {  // もし、計算結果が''なら表示も消す。
     $('.right_bar').html('ー');
     $('.right_bar_2').html('ー');
     }

--- a/app/assets/stylesheets/modules/_items.new.scss
+++ b/app/assets/stylesheets/modules/_items.new.scss
@@ -75,7 +75,7 @@
     display: block;
     width: 360px;
     height: 48px;
-    margin: 0 auto 20px;
+    margin: 15px auto 20px;
     border-radius: 5px;
     text-decoration: none;
     text-align: center;
@@ -202,13 +202,21 @@
 .price-group-border {
   position: flex;
   .sell-price-fee {
-  font-size: 13px;
-  padding: 50px 0  20px 30px;
-  border-bottom: solid 1px #efefef;
+    font-size: 13px;
+    padding: 50px 0  20px 30px;
+    border-bottom: solid 1px #efefef;
+    .right_bar {
+      float: right;
+      margin-right: 25px;
+  }
  }
  .sell-price-profit {
-  padding: 30px 0 30px 30px;
-  font-size: 13px;
+    padding: 30px 0 30px 30px;
+    font-size: 13px;
+    .right_bar_2 {
+      float: right;
+      margin-right: 25px;
+    }
 }
 }
 

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -141,11 +141,13 @@
                 .sell-price-fee
                   販売手数料  (10%)
                   .right_bar
+                    ー
             %li.price-group-border
               .clearfix
                 .sell-price-profit
                   販売利益
                   .right_bar_2
+                    ー
       .sell-main-content
         .sell-main__exhibit
           = f.submit "出品する", class: "sell-main__btn sell-main__btn--exhibition"

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -132,7 +132,7 @@
                   %p
                     ￥
                   %div
-                    = f.number_field :price, min:1, max:9999999, class: "sell-price-input__price-select", placeholder: "0"
+                    = f.number_field :price, min:1, max:9999999, class: "sell-price-input__price-select", id: "price_calc", placeholder: "0"
                 .sell-price-note
                   %p
                     300以上9999999以下で入力して下さい
@@ -140,14 +140,12 @@
               .clearfix
                 .sell-price-fee
                   販売手数料  (10%)
-                .sell-price-input
-                  .right
+                  .right_bar
             %li.price-group-border
               .clearfix
                 .sell-price-profit
                   販売利益
-                .sell-price-input
-                  .right
+                  .right_bar_2
       .sell-main-content
         .sell-main__exhibit
           = f.submit "出品する", class: "sell-main__btn sell-main__btn--exhibition"


### PR DESCRIPTION
# What
出品ページに価格を入力すると販売利益と販売手数料をページ遷移せず(Ajax)表示されるようにする

# Why
必須実装でもあり、出品者側から出品した時の利益と手数料が把握できた方が便利なため。

実装後ブラウザ表示
[![Screenshot from Gyazo](https://gyazo.com/f4efcbd819f9def008b30b21921db25d/raw)](https://gyazo.com/f4efcbd819f9def008b30b21921db25d)