### PR TITLE
Main page image display　出品画像一覧表示&sold out表示

### DIFF
--- a/app/assets/stylesheets/modules/_main.scss
+++ b/app/assets/stylesheets/modules/_main.scss
@@ -296,6 +296,28 @@
             margin: 0;
             z-index: auto;
           }
+          .sold {
+            position: relative;
+            top: 0px;
+            left: 0px;
+            .back-color {
+              background-color: red transparent;
+              height: 40px;
+              position: absolute;
+              top: 0;
+              border-bottom: 60px solid transparent;
+              border-left: 60px solid #EA352D;
+            }
+            .sold-mark {
+              font-size: 15px;
+              font-family: monospace;
+              line-height: 45px;
+              transform: rotate(-45deg);
+              position: absolute;
+              font-weight: bold;
+              color: white;
+            }
+          }
           .text {
             padding: 16px;
             h3 {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -48,6 +48,8 @@ class ItemsController < ApplicationController
   end
 
   def purchase
+    @item= Item.find(params[:id])
+    @item.update(buyer_id: current_user.id)
   end
 
   def category_children
@@ -67,7 +69,7 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item)
-      .permit(:name, :price, :description, :category_id, :size, :brand, :condition, :shipping_fee, :shipping_method, :shipping_date, :seller_id, item_images_attributes: [:image_url]).merge(seller_id: current_user.id)
+      .permit(:name, :price, :description, :category_id, :size, :brand, :condition, :shipping_fee, :shipping_method, :shipping_date, :buyer_id, :seller_id, item_images_attributes: [:image_url]).merge(seller_id: current_user.id)
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -48,7 +48,7 @@ class ItemsController < ApplicationController
   end
 
   def purchase
-    @item= Item.find(params[:id])
+    @item = Item.find(params[:id])
     @item.update(buyer_id: current_user.id)
   end
 

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -124,18 +124,38 @@
       = link_to "アーカイバ","#", class: "box__title"
       .box__lists
         - @items.each do |item|
-          .box__lists--list
-            = link_to item_path(item), class: "box__lists--list" do
-              .image
+          -if item.buyer_id.present? 
+            .box__lists--list
+              = link_to item_path(item), class: "box__lists--list" do
+                .image
+                .sold
+                  .back-color
+                  .sold-mark
+                    SOLD
+                  = image_tag item.item_images.first.image_url.to_s if item.item_images.first
+                .text
+                  %h3 
+                    = item.name
+                  .price
+                    %ul
+                      %li
+                        = item.price
+                        円
+                      %li 
+                        %i.fa.fa-star 0
+                    %p (税込)
+          -else
+            .box__lists--list
+              = link_to item_path(item), class: "box__lists--list" do
                 = image_tag item.item_images.first.image_url.to_s if item.item_images.first
-              .text
-                %h3 
-                  = item.name
-                .price
-                  %ul
-                    %li
-                      = item.price
-                      円
-                    %li 
-                      %i.fa.fa-star 0
-                  %p (税込)
+                .text
+                  %h3 
+                    = item.name
+                  .price
+                    %ul
+                      %li
+                        = item.price
+                        円
+                      %li 
+                        %i.fa.fa-star 0
+                    %p (税込)


### PR DESCRIPTION
# What
　ー　売り切れた商品に対し、sold outの表示をさせる
# Why
　ー　メインページを見ている際、売り切れた商品にsold outの表示がないと、
「お！これめっちゃ安い！前から欲しかったやつだぞ！！まだ売り切れてない！！！しゃあっ！！」と
テンションが絶頂にまで上がり、その商品をクリック。

「え、なんでだよ？売り切れじゃねえか！！メインページにsold out表示くらいさせとけよ！！！」
と
絶頂からの絶望・恨み・怒りを全て同時に感じたuser様から、
お問い合わせ先に大クレームが入る可能性がある為。



[![Image from Gyazo](https://i.gyazo.com/b1ac75afd6ff1be518bbffd143340212.gif)](https://gyazo.com/b1ac75afd6ff1be518bbffd143340212)