### PR TITLE
商品詳細ページのsold out表示、購入ボタン表示

### DIFF
--- a/app/assets/stylesheets/modules/_items.show.scss
+++ b/app/assets/stylesheets/modules/_items.show.scss
@@ -62,6 +62,28 @@
     &__images {
       width: 620px;
       margin-top: 16px;
+
+      .sold {
+        position: relative;
+        .back-color {
+          background-color: red transparent;
+          height: 200px;
+          position: absolute;
+          top: 0;
+          border-bottom: 200px solid transparent;
+          border-left: 200px solid #EA352D;
+        }
+        .sold-mark {
+          font-size: 55px;
+          font-family: monospace;
+          line-height: 140px;
+          transform: rotate(-45deg);
+          position: absolute;
+          font-weight: bold;
+          color: white;
+        }
+      }
+
       &--main {
         height: 346px;
         width: 560px;
@@ -73,7 +95,6 @@
         margin: 10px 30px 0;
         display: flex;
         flex-wrap: wrap;
-        justify-content: center;
         .other {
           height: 65px;
           width: 102px;

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -24,6 +24,11 @@
       = @item.name
     %ul.item__images
       %li
+        - if @item.buyer_id.present?
+          .sold
+            .back-color
+            .sold-mark
+              SOLD
         // 1枚目に登録した画像の表示
         = image_tag @item.item_images.first.image_url, alt: "メイン画像", class: "item__images--main"
         %ul.item__images--others
@@ -106,7 +111,7 @@
           = link_to "商品を編集する", edit_item_path(@item.id), method: :get, class: "item__edit--editBtn"
           or
           = link_to "削除", item_path(@item.id), method: :delete, data: {confirm: '本当に削除しますか?'}, class: "item__edit--deleteBtn"
-      - else
+      - elsif @item.buyer_id == nil
         .item__purchase
           = link_to "購入画面に進む", purchase_item_path, method: :get, class: "item__purchase--btn"
   .comment


### PR DESCRIPTION
# What
商品詳細ページにおいて、購入されている商品はメイン画像に「SOLD」マークが表示されるように実装。また、購入ボタンも出現しないようにすることで購入画面に進めないようになる。

# Why
購入された商品をユーザーが一目で判断できるようにするため。

# 実装確認GIF

・buyer_idが空の時（購入されていない商品）は通常通りの表示。
[![Image from Gyazo](https://i.gyazo.com/6c16072bbc1a800e3a62ec25184a1559.gif)](https://gyazo.com/6c16072bbc1a800e3a62ec25184a1559)



・buyer_idが埋まっている時（購入された商品）はSoldマークを表示、かつ購入ボタンを非表示
[![Image from Gyazo](https://i.gyazo.com/57a075c4beb524b4ed4599a3876200ed.gif)](https://gyazo.com/57a075c4beb524b4ed4599a3876200ed)