### PR TITLE
マイページのユーザー名表示

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -6,7 +6,7 @@
         .mypage-user__icon
           = image_tag asset_path ("material/icon/member_photo_noimage_thumb.png"), class: 'mypage-user__icon__image'
           .mypage-user__icon__nickname
-            current user name
+            = current_user.nickname
           .mypage-user__icon__number
             .mypage-user__icon__number__evaluation
               評価


### PR DESCRIPTION
# What
マイページにログインしているユーザーの名前表示の実装を行った。

# Why
フリマアプリの必須機能のため。

## 実装画面のキャプチャ
[![Screenshot from Gyazo](https://gyazo.com/c07c6412a051b416ca600e0f1ef93cff/raw)](https://gyazo.com/c07c6412a051b416ca600e0f1ef93cff)