### PR TITLE
メインページ出品画像３枚表示

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
 
   def index
-    @items = Item.all
+    @items = Item.limit(3).order('id DESC')
     @item_images = ItemImage.all
   end
   # @item.item_images.newという記述により、


### PR DESCRIPTION
# What
メインページのピックアップカテゴリ、ピックアップブランドのカテゴリの商品画像を最新３枚のみ表示するように設定した。

# Why
見本フリマサイトのUIに合わせるため。

## 実装画面のキャプチャ
[![Screenshot from Gyazo](https://gyazo.com/f4becb9ab7e934fedd02529eacacd547/raw)](https://gyazo.com/f4becb9ab7e934fedd02529eacacd547)

新たに商品出品後↓
[![Screenshot from Gyazo](https://gyazo.com/c801050a68ce9ebfa4e68bcd7bbaff6c/raw)](https://gyazo.com/c801050a68ce9ebfa4e68bcd7bbaff6c)