### PR TITLE
出品機能の画像投稿に関するバリデーションの設定

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,6 +20,7 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to root_path
     else
+      @item.item_images.new
       render :new
     end
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -21,6 +21,7 @@ class Item < ApplicationRecord
     validates :shipping_fee, presence: {message: "選択してください"}
     validates :shipping_method, presence: {message: "選択してください"}
     validates :shipping_date, presence: {message: "選択してください"}
+    validates :item_images
   end
 
   enum condition: { "新品、未使用": 1, "未使用に近い": 2, "目立った傷や汚れなし": 3, "やや傷や汚れあり": 4, "傷や汚れあり": 5, "全体的に状態が悪い": 6 }, _prefix: true


### PR DESCRIPTION
# What
商品出品時の画像にバリデーションがかかっていなかったため設置。
また商品を選択せずに出品ボタンを押すと、リダイレクト先のページでファイル選択ボタンが消えてしまう現象が確認できたため、消えないようにコードを修正。

# Why
バリデーションをかけずに画像なしのまま出品できてしまうと、
商品詳細画面等でエラーが生じてしまうため。

# 動作確認
[![Image from Gyazo](https://i.gyazo.com/ef9bb257221e50c16851b7e0d57d1653.gif)](https://gyazo.com/ef9bb257221e50c16851b7e0d57d1653)