### PR TITLE
メインページに表示される商品出品画像のサイズ統一

### DIFF
--- a/app/assets/stylesheets/modules/_main.scss
+++ b/app/assets/stylesheets/modules/_main.scss
@@ -289,12 +289,15 @@
           a {
             text-decoration: none;
           }
-          .image {
-            width: 220px;
-            position: relative;
-            overflow: hidden;
-            margin: 0;
+          img{
+            height: 200px;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            width: 100%;
             z-index: auto;
+            object-fit: cover;
           }
           .sold {
             position: relative;


### PR DESCRIPTION
# What
　メインページに表示される商品出品画像のサイズを統一する
# Why
　見栄えが良くなる。投稿画像によっては非常にロングなタイプもいる為、見栄えが悪くなる事を防ぐ。




# 今回の問題

image_uploader.rbに
  process resize_to_fit: [200, 300]
を記載していても、
商品出品後にメインページに反映する投稿画像のサイズが変わってしまう問題について


# 回答
メインページに表示される画像のサイズ指定をcss に記述してしまう事で、投稿画像のサイズがそれ以上大きくならないようにできます。