### PR TITLE
商品編集ページにおけるカテゴリー表示の修正

### DIFF
--- a/app/assets/javascripts/items/edit_category_form.js
+++ b/app/assets/javascripts/items/edit_category_form.js
@@ -1,0 +1,89 @@
+$(function(){
+  function appendOption(category){
+    var html = `<option value="${category.id}">${category.name}</option>`;
+    return html;
+  }
+
+  function appendChild(insertHTML) {
+    var childSelectEditHtml = '';
+    childSelectEditHtml = ` <div class="listing-select-wrapper--edit__child">
+                          <select class="listing-select-wrapper--edit__child--select" id="child_category_edit" name="item[category_id]" required="true">
+                            <option value="---">選択してください</option>
+                            ${insertHTML}
+                          </select>
+                        </div>`;
+    $('.listing-select-wrapper--edit').append(childSelectEditHtml);
+  }
+
+  function appendGrandChild(insertHTML) {
+    var grandchildSelectEditHtml = '';
+    grandchildSelectEditHtml = `<div class="listing-select-wrapper--edit__grandchild">
+                          <select class="listing-select-wrapper--edit__grandchild--select" id="grandchild_category_edit" name="item[category_id]" required="true">
+                            <option value="---">選択してください</option>
+                            ${insertHTML}
+                          </select>
+                        </div>`;
+    $('.listing-select-wrapper--edit').append(grandchildSelectEditHtml);
+  }
+
+// 親カテゴリーの値が変わった時の処理
+  $(document).on('change', '#parent_category_edit', function() {
+// 親カテゴリーのデータを取得して変数にいれる
+    var parentCategoryEdit = document.getElementById('parent_category_edit').value;
+    if (parentCategoryEdit != '選択してください'){
+      $.ajax({
+        url: '/items/category_children',
+        type: 'GET',
+        data: { productcategory: parentCategoryEdit },
+        dataType: 'json'
+      })
+// 成功した時の処理
+      .done(function(children){
+// 元々あった子カテゴリーと孫カテゴリーを消す。
+        $('.listing-select-wrapper--edit__child').remove();
+        $('.listing-select-wrapper--edit__grandchild').remove();
+// insertHTMLを定義して中身にオプションをつける。
+        var insertHTML = '';
+        children.forEach(function(child){
+          insertHTML += appendOption(child);
+        });
+// オプション付きのinsertHTMLをappendChildにいれる。
+        appendChild(insertHTML);
+      })
+      .fail(function(){
+        alert('カテゴリー取得に失敗しました');
+      })
+    }else {
+      $('#child_category_edit').remove();
+      $('#grandchild_category_edit').remove();
+    }
+  });
+
+  // 子カテゴリーとベースは同じ
+  $(document).on('change', '#child_category_edit', function(){
+    var childIdEdit = document.getElementById('child_category_edit').value;
+    if (childIdEdit !== '選択してください') {
+      $.ajax({
+        url: '/items/category_grandchildren',
+        type: 'GET',
+        data: { productcategory: childIdEdit },
+        dataType: 'json'
+      })
+      .done(function(grandchildren) {
+        if (grandchildren.length != 0) {
+          $('.listing-select-wrapper--edit__grandchild').remove();
+          var insertHTML = '';
+          grandchildren.forEach(function(grandchild){
+            insertHTML += appendOption(grandchild);
+          });
+          appendGrandChild(insertHTML);
+        }
+      })
+      .fail(function(){
+        alert('カテゴリー取得に失敗しました');
+      })
+    }else {
+      $('#grandchild_category_edit').remove();
+    }
+  })
+})

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,10 +33,15 @@ class ItemsController < ApplicationController
   end
 
   def update
-    if @item.update(item_params)
-      redirect_to item_path
-    else
+    #カテゴリーを孫まで選択していない場合、category_idが"---"と送られてくる。それは通したくないので条件分岐。
+    if item_params[:category_id] == "---"
       render :edit
+    else
+      if @item.update(item_params)
+        redirect_to item_path
+      else
+        render :edit
+      end
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,12 +36,10 @@ class ItemsController < ApplicationController
     #カテゴリーを孫まで選択していない場合、category_idが"---"と送られてくる。それは通したくないので条件分岐。
     if item_params[:category_id] == "---"
       render :edit
+    elsif @item.update(item_params)
+      redirect_to item_path
     else
-      if @item.update(item_params)
-        redirect_to item_path
-      else
-        render :edit
-      end
+      render :edit
     end
   end
 

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -69,8 +69,14 @@
                 必須
             %div
               .select-form
-                %i.fa.fa-chevron-down
-                = f.collection_select(:category_id, @parents, :id, :name, {prompt: "選択して下さい"}, {id: "category_select"})
+                -#元々データベースに保存されていたカテゴリーを表示するように記載。
+                .listing-select-wrapper--edit
+                  .listing-select-wrapper--edit__parent
+                    = f.collection_select :category_id, Category.roots, :id, :name ,{prompt: "選択してください", selected:  @item.category.parent.parent_id}, {required: true, class: 'listing-select-wrapper--edit__parent--select', id: 'parent_category_edit'}
+                  .listing-select-wrapper--edit__child
+                    = f.collection_select :category_id, @item.category.parent.parent.children, :id, :name ,{prompt: "選択してください", selected: @item.category.parent_id}, {required: true, class: 'listing-select-wrapper--edit__child--select', id: 'child_category_edit'}
+                  .listing-select-wrapper--edit__grandchild
+                    = f.collection_select :category_id, @item.category.parent.children, :id, :name ,{prompt: "選択してください", selected: @item.category.id}, {required: true, class: 'listing-select-wrapper--edit__grandchild--select', id: 'grandchild_category_edit'}
               .product_select-children
                 %p.error=@item.errors.messages[:category_id][0]
           .form-group


### PR DESCRIPTION
# What
カテゴリーが編集可能になるようにviewファイルを修正。
それに伴い、編集ページのカテゴリー選択の非同期通信化のために別ファイルを作成。
孫カテゴリーまで選択した状態でないと変更できないよう、コントローラーのupdateアクションを条件分岐。

# Why
ユーザーが正常に編集作業を行えるようにするため。

# 挙動確認

## 登録したカテゴリーが、カテゴリー選択欄に入った状態で編集画面に遷移する。
[![Image from Gyazo](https://i.gyazo.com/a04b62dede8834429b2d34ac752c41e8.gif)](https://gyazo.com/a04b62dede8834429b2d34ac752c41e8)

## 非同期通信でカテゴリー選択ができる
[![Image from Gyazo](https://i.gyazo.com/825242fdd0d317fab13a4c65d9340e52.gif)](https://gyazo.com/825242fdd0d317fab13a4c65d9340e52)

## 変更内容が詳細ページに反映される
[![Image from Gyazo](https://i.gyazo.com/751b17538c44712e0e98610848789acc.gif)](https://gyazo.com/751b17538c44712e0e98610848789acc)

## 孫カテゴリーまで選択しなかった場合、変更するボタンを押しても編集ページに戻る
[![Image from Gyazo](https://i.gyazo.com/e955f5345ef359c9c97c11537facdd8d.gif)](https://gyazo.com/e955f5345ef359c9c97c11537facdd8d)